### PR TITLE
Update chess.js dependency and refactor glyph handling to NAGs

### DIFF
--- a/functions/build-moment.js
+++ b/functions/build-moment.js
@@ -7,7 +7,7 @@ module.exports = ({
   fen,
   comment,
   suffix,
-  glyph,
+  nags,
   from,
   to,
   headers,
@@ -33,8 +33,8 @@ module.exports = ({
   if (suffix) {
     moment.suffix = suffix;
   }
-  if (glyph) {
-    moment.glyph = glyph;
+  if (nags) {
+    moment.nags = nags;
   }
   if (headers) {
     moment.headers = headers;

--- a/functions/extras/moments-to-pgn.js
+++ b/functions/extras/moments-to-pgn.js
@@ -142,9 +142,11 @@ const momentsToPgn = (moments) => {
       pgn += moment.suffix;
     }
 
-    // Add glyph if present (keep as NAG code from original PGN)
-    if (moment.glyph) {
-      pgn += ` ${moment.glyph}`;
+    // Add NAGs if present (keep as NAG codes from original PGN)
+    if (moment.nags && moment.nags.length > 0) {
+      moment.nags.forEach((nag) => {
+        pgn += ` $${nag}`;
+      });
     }
 
     // Add comment if present

--- a/functions/parser.js
+++ b/functions/parser.js
@@ -1,9 +1,7 @@
 const { Chess } = require('chess.js');
-const { invert } = require('lodash');
 const { initial } = require('./fen');
 const pgn = require('./pgn');
 const moment = require('./moment');
-const glyphs = require('../constants/glyphs');
 
 module.exports = (moves, fen = initial, depth = 1, headers = null) => {
   const chess = new Chess();
@@ -32,7 +30,7 @@ module.exports = (moves, fen = initial, depth = 1, headers = null) => {
       to: item.to,
       comment: chess.getComment(),
       suffix: chess.getSuffixAnnotation(),
-      glyph: invert(glyphs)[chess.getGlyph()],
+      nags: chess.getNags().length > 0 ? chess.getNags() : undefined,
       fen: chess.fen(),
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "chess.js": "github:brobert1/chess.js#master"
+        "chess.js": "github:jhlywa/chess.js#master"
       },
       "devDependencies": {
         "chai": "^4.3.7",
@@ -295,7 +295,7 @@
     },
     "node_modules/chess.js": {
       "version": "1.4.0",
-      "resolved": "git+ssh://git@github.com/brobert1/chess.js.git#48b4e25bd64911f1019d7d8bbfdef2a95428e088",
+      "resolved": "git+ssh://git@github.com/jhlywa/chess.js.git#ca935bf44076e3d1c6e06922c7a9a2f28d959d2a",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -2156,8 +2156,8 @@
       "dev": true
     },
     "chess.js": {
-      "version": "git+ssh://git@github.com/brobert1/chess.js.git#48b4e25bd64911f1019d7d8bbfdef2a95428e088",
-      "from": "chess.js@github:brobert1/chess.js#master"
+      "version": "git+ssh://git@github.com/jhlywa/chess.js.git#ca935bf44076e3d1c6e06922c7a9a2f28d959d2a",
+      "from": "chess.js@github:jhlywa/chess.js#master"
     },
     "chokidar": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "chess.js": "github:brobert1/chess.js#master"
+    "chess.js": "github:jhlywa/chess.js#master"
   },
   "devDependencies": {
     "chai": "^4.3.7",

--- a/tests/chess-glyph.test.js
+++ b/tests/chess-glyph.test.js
@@ -10,8 +10,8 @@ describe('Chess glyphs: Basic examples', () => {
     const moments = flat(originalPgn);
 
     // Assert
-    expect(moments[1]?.glyph).to.equal('$7');
-    expect(moments[3]?.glyph).to.equal('$22');
+    expect(moments[1]?.nags).to.deep.equal([7]);
+    expect(moments[3]?.nags).to.deep.equal([22]);
   });
 
   it('Has multiple different glyphs', () => {
@@ -22,10 +22,10 @@ describe('Chess glyphs: Basic examples', () => {
     const moments = flat(originalPgn);
 
     // Assert
-    expect(moments[1]?.glyph).to.equal('$10');
-    expect(moments[3]?.glyph).to.equal('$13');
-    expect(moments[5]?.glyph).to.equal('$14');
-    expect(moments[7]?.glyph).to.equal('$16');
+    expect(moments[1]?.nags).to.deep.equal([10]);
+    expect(moments[3]?.nags).to.deep.equal([13]);
+    expect(moments[5]?.nags).to.deep.equal([14]);
+    expect(moments[7]?.nags).to.deep.equal([16]);
   });
 
   it('Works with both suffix and glyph on same move', () => {
@@ -37,8 +37,20 @@ describe('Chess glyphs: Basic examples', () => {
 
     // Assert
     expect(moments[1]?.suffix).to.equal('!');
-    expect(moments[1]?.glyph).to.equal('$7');
+    expect(moments[1]?.nags).to.deep.equal([7]);
     expect(moments[2]?.suffix).to.equal('?!');
-    expect(moments[2]?.glyph).to.equal('$22');
+    expect(moments[2]?.nags).to.deep.equal([22]);
+  });
+
+  it('Supports multiple NAGs on same move', () => {
+    // Arrange
+    const originalPgn = '1. e4 $7 $10 a6 2. d4 $16 $36 $40 *';
+
+    // Act
+    const moments = flat(originalPgn);
+
+    // Assert
+    expect(moments[1]?.nags).to.deep.equal([7, 10]);
+    expect(moments[3]?.nags).to.deep.equal([16, 36, 40]);
   });
 });

--- a/tests/moments-to-pgn.test.js
+++ b/tests/moments-to-pgn.test.js
@@ -63,6 +63,18 @@ describe('moments to PGN: Basic examples', () => {
     expect(newPgn).to.include('1. e4! $7 d5?! $22 *');
   });
 
+  it('converts moments with multiple NAGs on same move', () => {
+    // Arrange
+    const originalPgn = '1. e4 $7 $10 a6 2. d4 $16 $36 $40 *';
+    const moments = flat(originalPgn);
+
+    // Act
+    const newPgn = momentsToPgn(moments);
+
+    // Assert
+    expect(newPgn).to.include('1. e4 $7 $10 a6 2. d4 $16 $36 $40 *');
+  });
+
   it('converts moments with variations', () => {
     // Arrange
     const originalPgn = '1. e4 e5 (1... c5) 2. Nf3 *';


### PR DESCRIPTION
- Changed chess.js dependency from brobert1 to jhlywa in package.json and package-lock.json.
- Refactored code to replace glyph handling with NAGs in build-moment.js, parser.js, and moments-to-pgn.js.
- Updated tests to reflect changes from glyphs to NAGs.